### PR TITLE
[Build] Add basic CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+
+project( boostdep LANGUAGES CXX )
+
+add_executable( boostdep src/boostdep.cpp )
+
+find_package( Boost COMPONENTS filesystem REQUIRED )
+target_link_libraries( boostdep Boost::filesystem )
+


### PR DESCRIPTION
This not part of a fancy boost wide solution, but just adds a simple CMakeLists.txt file that allows to compile boostdep using cmake - provided cmake can find boost filesystem.

In the future this dependency should become optional when compiling with a c++17 toolchain.