### PR TITLE
depinst/depinst.py: Update argument library

### DIFF
--- a/depinst/depinst.py
+++ b/depinst/depinst.py
@@ -226,6 +226,7 @@ if( __name__ == "__main__" ):
     parser.add_argument( '-N', '--ignore', help="exclude top-level dependency even when found in scan; can be repeated", metavar='LIB', action='append', default=[] )
     parser.add_argument( '-I', '--include', help="additional subdirectory to scan; can be repeated", metavar='DIR', action='append', default=[] )
     parser.add_argument( '-g', '--git_args', help="additional arguments to `git submodule update`", default='', action='store' )
+    parser.add_argument( '-u', '--update', help='update library argument as well', action='store_true' )
     parser.add_argument( 'library', help="name of library to scan ('libs/' will be prepended)" )
 
     args = parser.parse_args()
@@ -251,6 +252,10 @@ if( __name__ == "__main__" ):
     m = args.library
 
     deps = { m : 1 }
+
+    if args.update:
+        vprint( 1, 'Update submodule:', m )
+        install_modules( [m], args.git_args )
 
     dirs = [ 'include', 'src', 'test' ]
 


### PR DESCRIPTION
At present `depinst.py` does not update argument itself, so, for example,
```shellsession
$ git clone --depth 1 https://github.com/boostorg/boost.git
$ cd boost
$ git submodule update --init tools/boostdep
$ python3 tools/boostdep/depinst/depinst.py -v -g'--depth=1' format
...
Submodule path 'tools/build': checked out 'ceddb211c6e0ab7f0abf6c253f1f6e392d6a38b4'
Directories to scan: include src test
Scanning module format
Scanning directory libs/format/include
Scanning directory libs/format/src
Scanning directory libs/format/test
$ git submodule | fgrep format
-894f465d843d999b5c024a49f90a5a1013edd368 libs/format
```
`format` and its dependence (e.g., `optional`) are not updated because `libs/format` is empty.

The PR fixes this.