### PR TITLE
Add CSV output to ease dependency importation from tools

### DIFF
--- a/doc/src/boostdep.qbk
+++ b/doc/src/boostdep.qbk
@@ -258,6 +258,10 @@ Usage:
                \[--html-title <title>\] \[--html-footer <footer>\]
                \[--html-stylesheet <stylesheet>\] \[--html-prefix <prefix>\]
                \[--html\]
+               \[--csv\]
+               \[--csv-separator <separator>\]
+               \[--csv-[no-]table-marker\]
+               \[--csv-[no-]table-header\]
 ]
 
 [endsect]
@@ -777,6 +781,111 @@ the =test= subdirectory is not scanned.
 [section --html]
 
 =--html= switches to HTML output mode (the default is plain text). It must precede the commands that generate output.
+
+[endsect]
+
+[section --csv]
+
+=--csv= switches to CSV output mode (the default is plain text). It must precede the commands that generate output.
+It supports the same operations supported by =--html= (=--module-overview=, =--module-levels=...).
+By default, each operation will create a table prefixed by a table marker that describes the operation and a header
+describing column names. For instance, the following command:
+
+[pre
+dist/bin/boostdep --csv --primary assert --secondary container_hash --header boost/container/deque.hpp --reverse interprocess --subset assert
+]
+
+can output:
+
+[pre
+
+[Primary],assert
+Module,Header,From
+config,boost/config.hpp,boost/assert.hpp boost/assert/source_location.hpp
+config,boost/config/workaround.hpp,boost/assert/source_location.hpp
+config,boost/cstdint.hpp,boost/assert/source_location.hpp
+
+[Secondary],container_hash
+Module,Adds
+type_traits,static_assert
+
+[Header],boost/container/deque.hpp,container
+Module,From
+interprocess,boost/interprocess/containers/deque.hpp
+thread,boost/thread/csbl/deque.hpp
+
+[Reverse],interprocess
+Module,Header,From
+flyweight,boost/interprocess/detail/intermodule_singleton.hpp,boost/flyweight/intermodule_holder.hpp
+log,boost/interprocess/creation_tags.hpp,libs/log/src/posix/ipc_reliable_message_queue.cpp
+log,boost/interprocess/detail/workaround.hpp,libs/log/src/posix/ipc_sync_wrappers.hpp
+log,boost/interprocess/exceptions.hpp,libs/log/src/posix/ipc_reliable_message_queue.cpp
+log,boost/interprocess/mapped_region.hpp,libs/log/src/posix/ipc_reliable_message_queue.cpp
+log,boost/interprocess/permissions.hpp,libs/log/src/permissions.cpp libs/log/src/posix/ipc_reliable_message_queue.cpp
+log,boost/interprocess/shared_memory_object.hpp,libs/log/src/posix/ipc_reliable_message_queue.cpp
+log,boost/interprocess/sync/interprocess_condition.hpp,libs/log/src/posix/ipc_sync_wrappers.hpp
+log,boost/interprocess/sync/interprocess_mutex.hpp,libs/log/src/posix/ipc_sync_wrappers.hpp
+
+[Subset],assert
+Module,Path
+config,boost/assert.hpp -> boost/config.hpp
+config,boost/assert/source_location.hpp -> boost/config.hpp
+
+]
+
+[endsect]
+
+[section --csv-separator]
+
+[^--csv-separator /separator/] sets the CSV column separator string. The default separator is the comma character (','). It has no effect if =--csv= is not given.
+The following command will create a CSV file using semicolon (';') as the separator:
+
+[pre
+dist/bin/boostdep --csv --csv-separator ';' --primary assert
+]
+
+[endsect]
+
+[section --csv-table-marker]
+
+=--csv-table-marker= activates a marker line for each table that is created in the CSV file in the form `[Operation] <csv-separator> <arg>`.
+It's activated by default. This allows the detection of each operation, which creates its own table in the CSV file.
+If =--csv-no-table-marker= is given the marker line is not emitted. It has no effect if =--csv= is not given. The following command
+
+[pre
+dist/bin/boostdep --csv --csv-no-table-marker --csv-no-table-header --primary assert
+]
+
+will output a standard CSV file with no `[Primary],assert` marker line:
+
+[pre
+Module,Header,From
+config,boost/config.hpp,boost/assert.hpp boost/assert/source_location.hpp
+config,boost/config/workaround.hpp,boost/assert/source_location.hpp
+config,boost/cstdint.hpp,boost/assert/source_location.hpp
+]
+
+[endsect]
+
+[section --csv-table-header]
+
+=--csv-table-header= activates a header line describing each column of each table that is created in the CSV file. 
+It's activated by default. This allows easier identification of the column meaning and easier import to a database. 
+If =--csv-no-table-marker= is given the marker line is not emitted. It has no effect if =--csv= is not given.
+The following command
+
+[pre
+dist/bin/boostdep --csv --csv-no-table-header --primary assert
+]
+
+will output a standard CSV file with no `Module,Header,From` header line
+
+[pre
+[Primary],assert
+config,boost/config.hpp,boost/assert.hpp boost/assert/source_location.hpp
+config,boost/config/workaround.hpp,boost/assert/source_location.hpp
+config,boost/cstdint.hpp,boost/assert/source_location.hpp
+]
 
 [endsect]
 

--- a/src/boostdep.cpp
+++ b/src/boostdep.cpp
@@ -976,7 +976,7 @@ static void output_module_level_report( module_level_actions & actions )
 
     // compute acyclic levels
 
-    for( int k = 1, n = s_modules.size(); k < n; ++k )
+    for( std::size_t k = 1, n = s_modules.size(); k < n; ++k )
     {
         for( std::map< std::string, std::set< std::string > >::iterator i = s_module_deps.begin(); i != s_module_deps.end(); ++i )
         {
@@ -1015,7 +1015,7 @@ static void output_module_level_report( module_level_actions & actions )
 
     // compute levels for cyclic modules
 
-    for( int k = 1, n = s_modules.size(); k < n; ++k )
+    for( std::size_t k = 1, n = s_modules.size(); k < n; ++k )
     {
         for( std::map< std::string, std::set< std::string > >::iterator i = s_module_deps.begin(); i != s_module_deps.end(); ++i )
         {

--- a/src/boostdep.cpp
+++ b/src/boostdep.cpp
@@ -168,6 +168,7 @@ static void scan_header_dependencies( std::string const & header, std::istream &
 struct module_primary_actions
 {
     virtual void heading( std::string const & module ) = 0;
+    virtual void footer( std::string const & module )    = 0;
 
     virtual void module_start( std::string const & module ) = 0;
     virtual void module_end( std::string const & module ) = 0;
@@ -281,6 +282,8 @@ static void scan_module_dependencies( std::string const & module, module_primary
 
         actions.module_end( i->first );
     }
+
+    actions.footer( module );
 }
 
 // module depends on [ module, module... ]
@@ -304,6 +307,10 @@ struct build_mdmap_actions: public module_primary_actions
     void heading( std::string const & module )
     {
         module_ = module;
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -365,6 +372,7 @@ static void output_module_primary_report( std::string const & module, module_pri
 struct module_secondary_actions
 {
     virtual void heading( std::string const & module ) = 0;
+    virtual void footer( std::string const & module )    = 0;
 
     virtual void module_start( std::string const & module ) = 0;
     virtual void module_end( std::string const & module ) = 0;
@@ -424,6 +432,8 @@ static void output_module_secondary_report( std::string const & module, std::set
             deps = deps2;
         }
     }
+
+    actions.footer( module );
 }
 
 static void output_module_secondary_report( std::string const & module, module_secondary_actions & actions )
@@ -434,6 +444,7 @@ static void output_module_secondary_report( std::string const & module, module_s
 struct header_inclusion_actions
 {
     virtual void heading( std::string const & header, std::string const & module ) = 0;
+    virtual void footer( std::string const & header, std::string const & module ) = 0;
 
     virtual void module_start( std::string const & module ) = 0;
     virtual void module_end( std::string const & module ) = 0;
@@ -508,6 +519,8 @@ static void output_header_inclusion_report( std::string const & header, header_i
 
         actions.module_end( i->first );
     }
+
+    actions.footer( header, module );
 }
 
 // output_module_primary_report
@@ -517,6 +530,10 @@ struct module_primary_txt_actions: public module_primary_actions
     void heading( std::string const & module )
     {
         std::cout << "Primary dependencies for " << module << ":\n\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -549,6 +566,10 @@ struct module_primary_html_actions: public module_primary_actions
     void heading( std::string const & module )
     {
         std::cout << "\n\n<h1 id=\"primary-dependencies\">Primary dependencies for <em>" << module << "</em></h1>\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -599,6 +620,10 @@ struct module_secondary_txt_actions: public module_secondary_actions
         std::cout << "Secondary dependencies for " << module << ":\n\n";
     }
 
+    void footer( std::string const & /*module */ )
+    {
+    }
+
     void module_start( std::string const & module )
     {
         std::cout << module << ":\n";
@@ -622,6 +647,10 @@ struct module_secondary_html_actions: public module_secondary_actions
     void heading( std::string const & module )
     {
         std::cout << "\n\n<h1 id=\"secondary-dependencies\">Secondary dependencies for <em>" << module << "</em></h1>\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -664,6 +693,10 @@ struct header_inclusion_txt_actions: public header_inclusion_actions
         std::cout << "Inclusion report for <" << header << "> (in module " << module << "):\n\n";
     }
 
+    void footer( std::string const & /*header*/, std::string const & /*module */ )
+    {
+    }
+
     void module_start( std::string const & module )
     {
         std::cout << "    from " << module << ":\n";
@@ -685,6 +718,10 @@ struct header_inclusion_html_actions: public header_inclusion_actions
     void heading( std::string const & header, std::string const & module )
     {
         std::cout << "<h1>Inclusion report for <code>&lt;" << header << "&gt;</code> (in module <em>" << module << "</em>)</h1>\n";
+    }
+
+    void footer( std::string const & /*header*/, std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -722,6 +759,7 @@ static void output_header_report( std::string const & header, bool html )
 struct module_reverse_actions
 {
     virtual void heading( std::string const & module ) = 0;
+    virtual void footer( std::string const & module ) = 0;
 
     virtual void module_start( std::string const & module ) = 0;
     virtual void module_end( std::string const & module ) = 0;
@@ -772,6 +810,8 @@ static void output_module_reverse_report( std::string const & module, module_rev
 
         actions.module_end( *i );
     }
+
+    actions.footer( module );
 }
 
 struct module_reverse_txt_actions: public module_reverse_actions
@@ -779,6 +819,10 @@ struct module_reverse_txt_actions: public module_reverse_actions
     void heading( std::string const & module )
     {
         std::cout << "Reverse dependencies for " << module << ":\n\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -811,6 +855,10 @@ struct module_reverse_html_actions: public module_reverse_actions
     void heading( std::string const & module )
     {
         std::cout << "\n\n<h1 id=\"reverse-dependencies\">Reverse dependencies for <em>" << module << "</em></h1>\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -1461,6 +1509,10 @@ static void output_module_weight_report( module_weight_actions & actions )
             module_ = module;
         }
 
+        void footer( std::string const & /*module */ )
+        {
+        }
+
         void module_start( std::string const & /*module*/ )
         {
         }
@@ -1699,6 +1751,7 @@ static void output_module_weight_report( bool html )
 struct module_subset_actions
 {
     virtual void heading( std::string const & module ) = 0;
+    virtual void footer( std::string const & module ) = 0;
 
     virtual void module_start( std::string const & module ) = 0;
     virtual void module_end( std::string const & module ) = 0;
@@ -1822,6 +1875,8 @@ static void output_module_subset_report_( std::string const & module, std::set<s
 
         actions.module_end( i->first );
     }
+
+    actions.footer( module );
 }
 
 static void output_module_subset_report( std::string const & module, bool track_sources, bool track_tests, module_subset_actions & actions )
@@ -1846,6 +1901,10 @@ struct module_subset_txt_actions: public module_subset_actions
     void heading( std::string const & module )
     {
         std::cout << "Subset dependencies for " << module << ":\n\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -1883,6 +1942,10 @@ struct module_subset_html_actions: public module_subset_actions
     void heading( std::string const & module )
     {
         std::cout << "\n\n<h1 id=\"subset-dependencies\">Subset dependencies for <em>" << module << "</em></h1>\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -1975,6 +2038,10 @@ struct module_test_primary_actions: public module_primary_actions
         std::cout << "Test dependencies for " << module << ":\n\n";
     }
 
+    void footer( std::string const & /*module */ )
+    {
+    }
+
     void module_start( std::string const & module )
     {
         std::cout << module << "\n";
@@ -2008,6 +2075,10 @@ struct module_test_secondary_actions: public module_secondary_actions
     }
 
     void heading( std::string const & /*module*/ )
+    {
+    }
+
+    void footer( std::string const & /*module */ )
     {
     }
 
@@ -2057,6 +2128,10 @@ struct collect_primary_dependencies: public module_primary_actions
     std::set< std::string > set_;
 
     void heading( std::string const & )
+    {
+    }
+
+    void footer( std::string const & /*module */ )
     {
     }
 
@@ -2357,6 +2432,10 @@ struct module_brief_primary_actions: public module_primary_actions
         std::cout << "# Primary dependencies\n\n";
     }
 
+    void footer( std::string const & /*module */ )
+    {
+    }
+
     void module_start( std::string const & module )
     {
         std::cout << module << "\n";
@@ -2391,6 +2470,10 @@ struct module_brief_secondary_actions: public module_secondary_actions
     void heading( std::string const & /*module*/ )
     {
         std::cout << "# Secondary dependencies\n\n";
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & /*module*/ )
@@ -2438,6 +2521,10 @@ struct missing_header_actions: public module_primary_actions
     void heading( std::string const & module )
     {
         module_ = module;
+    }
+
+    void footer( std::string const & /*module */ )
+    {
     }
 
     void module_start( std::string const & module )
@@ -2498,6 +2585,10 @@ struct primary_pkgconfig_actions: public module_primary_actions
     std::string list_;
 
     void heading( std::string const & )
+    {
+    }
+
+    void footer( std::string const & /*module */ )
     {
     }
 

--- a/src/boostdep.cpp
+++ b/src/boostdep.cpp
@@ -26,6 +26,12 @@
 
 namespace fs = boost::filesystem;
 
+enum output_format
+{
+   txt_output = 0,
+   html_output = 1
+};
+
 // header -> module
 static std::map< std::string, std::string > s_header_map;
 
@@ -597,9 +603,9 @@ struct module_primary_html_actions: public module_primary_actions
     }
 };
 
-static void output_module_primary_report( std::string const & module, bool html, bool track_sources, bool track_tests )
+static void output_module_primary_report( std::string const & module, output_format out_fmt, bool track_sources, bool track_tests )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_primary_html_actions actions;
         output_module_primary_report( module, actions, track_sources, track_tests );
@@ -670,9 +676,9 @@ struct module_secondary_html_actions: public module_secondary_actions
     }
 };
 
-static void output_module_secondary_report( std::string const & module, bool html )
+static void output_module_secondary_report( std::string const & module, output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_secondary_html_actions actions;
         output_module_secondary_report( module, actions );
@@ -740,9 +746,9 @@ struct header_inclusion_html_actions: public header_inclusion_actions
     }
 };
 
-static void output_header_report( std::string const & header, bool html )
+static void output_header_report( std::string const & header, output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         header_inclusion_html_actions actions;
         output_header_inclusion_report( header, actions );
@@ -886,9 +892,9 @@ struct module_reverse_html_actions: public module_reverse_actions
     }
 };
 
-static void output_module_reverse_report( std::string const & module, bool html )
+static void output_module_reverse_report( std::string const & module, output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_reverse_html_actions actions;
         output_module_reverse_report( module, actions );
@@ -1239,9 +1245,9 @@ struct module_level_html_actions: public module_level_actions
     }
 };
 
-static void output_module_level_report( bool html )
+static void output_module_level_report( output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_level_html_actions actions;
         output_module_level_report( actions );
@@ -1351,9 +1357,9 @@ struct module_overview_html_actions: public module_overview_actions
     }
 };
 
-static void output_module_overview_report( bool html )
+static void output_module_overview_report( output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_overview_html_actions actions;
         output_module_overview_report( actions );
@@ -1732,9 +1738,9 @@ struct module_weight_html_actions: public module_weight_actions
     }
 };
 
-static void output_module_weight_report( bool html )
+static void output_module_weight_report( output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_weight_html_actions actions;
         output_module_weight_report( actions );
@@ -1976,9 +1982,9 @@ struct module_subset_html_actions: public module_subset_actions
     }
 };
 
-static void output_module_subset_report( std::string const & module, bool track_sources, bool track_tests, bool html )
+static void output_module_subset_report( std::string const & module, bool track_sources, bool track_tests, output_format out_fmt )
 {
-    if( html )
+    if( out_fmt == html_output )
     {
         module_subset_html_actions actions;
         output_module_subset_report( module, track_sources, track_tests, actions );
@@ -2699,7 +2705,7 @@ static void output_pkgconfig( std::string const & module, std::string const & ve
 
 // --subset-for
 
-static void output_directory_subset_report( std::string const & module, std::set<std::string> const & headers, bool html )
+static void output_directory_subset_report( std::string const & module, std::set<std::string> const & headers, output_format out_fmt )
 {
     for( std::set<std::string>::const_iterator i = headers.begin(); i != headers.end(); ++i )
     {
@@ -2718,7 +2724,7 @@ static void output_directory_subset_report( std::string const & module, std::set
         }
     }
 
-    if( html )
+    if( out_fmt == html_output )
     {
         module_subset_html_actions actions;
         output_module_subset_report_( module, headers, actions );
@@ -2990,7 +2996,7 @@ int main( int argc, char const* argv[] )
         std::cerr << x.what() << std::endl;
     }
 
-    bool html = false;
+    output_format out_fmt = txt_output;
     bool secondary = false;
     bool track_sources = true;
     bool track_tests = false;
@@ -3051,9 +3057,9 @@ int main( int argc, char const* argv[] )
         }
         else if( option == "--html" )
         {
-            if( !html )
+            if( out_fmt != html_output )
             {
-                html = true;
+                out_fmt = html_output;
                 output_html_header( html_title, html_stylesheet, html_prefix );
             }
         }
@@ -3077,7 +3083,7 @@ int main( int argc, char const* argv[] )
         {
             if( i + 1 < argc )
             {
-                output_module_primary_report( argv[ ++i ], html, track_sources, track_tests );
+                output_module_primary_report( argv[ ++i ], out_fmt, track_sources, track_tests );
             }
         }
         else if( option == "--secondary" )
@@ -3085,7 +3091,7 @@ int main( int argc, char const* argv[] )
             if( i + 1 < argc )
             {
                 enable_secondary( secondary, track_sources, track_tests );
-                output_module_secondary_report( argv[ ++i ], html );
+                output_module_secondary_report( argv[ ++i ], out_fmt );
             }
         }
         else if( option == "--reverse" )
@@ -3093,7 +3099,7 @@ int main( int argc, char const* argv[] )
             if( i + 1 < argc )
             {
                 enable_secondary( secondary, track_sources, track_tests );
-                output_module_reverse_report( argv[ ++i ], html );
+                output_module_reverse_report( argv[ ++i ], out_fmt );
             }
         }
         else if( option == "--header" )
@@ -3101,7 +3107,7 @@ int main( int argc, char const* argv[] )
             if( i + 1 < argc )
             {
                 enable_secondary( secondary, track_sources, track_tests );
-                output_header_report( argv[ ++i ], html );
+                output_header_report( argv[ ++i ], out_fmt );
             }
         }
         else if( option == "--subset" )
@@ -3109,7 +3115,7 @@ int main( int argc, char const* argv[] )
             if( i + 1 < argc )
             {
                 enable_secondary( secondary, track_sources, track_tests );
-                output_module_subset_report( argv[ ++i ], track_sources, track_tests, html );
+                output_module_subset_report( argv[ ++i ], track_sources, track_tests, out_fmt );
             }
         }
         else if( option == "--test" )
@@ -3137,17 +3143,17 @@ int main( int argc, char const* argv[] )
         else if( option == "--module-levels" )
         {
             enable_secondary( secondary, track_sources, track_tests );
-            output_module_level_report( html );
+            output_module_level_report( out_fmt );
         }
         else if( option == "--module-overview" )
         {
             enable_secondary( secondary, track_sources, track_tests );
-            output_module_overview_report( html );
+            output_module_overview_report( out_fmt );
         }
         else if( option == "--module-weights" )
         {
             enable_secondary( secondary, track_sources, track_tests );
-            output_module_weight_report( html );
+            output_module_weight_report( out_fmt );
         }
         else if( option == "--list-dependencies" )
         {
@@ -3191,7 +3197,7 @@ int main( int argc, char const* argv[] )
                 std::set<std::string> headers;
                 add_module_headers( module, headers );
 
-                output_directory_subset_report( module, headers, html );
+                output_directory_subset_report( module, headers, out_fmt );
             }
             else
             {
@@ -3242,12 +3248,12 @@ int main( int argc, char const* argv[] )
         }
         else if( s_modules.count( option ) )
         {
-            output_module_primary_report( option, html, track_sources, track_tests );
+            output_module_primary_report( option, out_fmt, track_sources, track_tests );
         }
         else if( s_header_map.count( option ) )
         {
             enable_secondary( secondary, track_sources, track_tests );
-            output_header_report( option, html );
+            output_header_report( option, out_fmt );
         }
         else
         {
@@ -3255,7 +3261,7 @@ int main( int argc, char const* argv[] )
         }
     }
 
-    if( html )
+    if( out_fmt == html_output )
     {
         output_html_footer( html_footer );
     }

--- a/src/boostdep.cpp
+++ b/src/boostdep.cpp
@@ -1195,7 +1195,7 @@ static void output_module_level_report( module_level_actions & actions )
                     level = std::max( level, level_map[ *j ] + 1 );
                 }
 
-                if( level == k )
+                if( level == static_cast<int>(k) )
                 {
                     level_map[ i->first ] = level;
                     // std::cerr << i->first << ": " << level << std::endl;

--- a/src/boostdep.cpp
+++ b/src/boostdep.cpp
@@ -1490,7 +1490,7 @@ static void output_module_weight_report( module_weight_actions & actions )
 
     for( std::set< std::string >::const_iterator i = s_modules.begin(); i != s_modules.end(); ++i )
     {
-        int w = s_module_deps[ *i ].size() + secondary_deps[ *i ].size();
+        int w = static_cast<int>( s_module_deps[ *i ].size() + secondary_deps[ *i ].size() );
         modules_by_weight[ w ].insert( *i );
     }
 
@@ -1512,7 +1512,7 @@ static void output_module_weight_report( module_weight_actions & actions )
 
                 for( std::set< std::string >::const_iterator k = s_module_deps[ *j ].begin(); k != s_module_deps[ *j ].end(); ++k )
                 {
-                    int w = s_module_deps[ *k ].size() + secondary_deps[ *k ].size();
+                    int w = static_cast<int>( s_module_deps[ *k ].size() + secondary_deps[ *k ].size() );
                     actions.module_primary( *k, w );
                 }
 
@@ -1525,7 +1525,7 @@ static void output_module_weight_report( module_weight_actions & actions )
 
                 for( std::set< std::string >::const_iterator k = secondary_deps[ *j ].begin(); k != secondary_deps[ *j ].end(); ++k )
                 {
-                    int w = s_module_deps[ *k ].size() + secondary_deps[ *k ].size();
+                    int w = static_cast<int>( s_module_deps[ *k ].size() + secondary_deps[ *k ].size() );
                     actions.module_secondary( *k, w );
                 }
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,3 +10,5 @@ path-constant HERE : . ;
 
 run ../src/boostdep.cpp /boost//filesystem : --boost-root $(ROOT) --capture-output assert --compare-output $(HERE)/assert-primary.txt : : : assert-primary ;
 run ../src/boostdep.cpp /boost//filesystem : --boost-root $(ROOT) --capture-output --secondary bind --compare-output $(HERE)/bind-secondary.txt : : : bind-secondary ;
+run ../src/boostdep.cpp /boost//filesystem : --boost-root $(ROOT) --csv --capture-output assert --compare-output $(HERE)/assert-primary.csv : : : assert-primary-csv ;
+run ../src/boostdep.cpp /boost//filesystem : --boost-root $(ROOT) --csv --capture-output --secondary bind --compare-output $(HERE)/bind-secondary.csv : : : bind-secondary-csv ;

--- a/test/assert-primary.csv
+++ b/test/assert-primary.csv
@@ -1,0 +1,6 @@
+[Primary],assert
+Module,Header,From
+config,boost/config.hpp,boost/assert.hpp boost/assert/source_location.hpp
+config,boost/config/workaround.hpp,boost/assert/source_location.hpp
+config,boost/cstdint.hpp,boost/assert/source_location.hpp
+

--- a/test/bind-secondary.csv
+++ b/test/bind-secondary.csv
@@ -1,0 +1,6 @@
+[Secondary],bind
+Module,Adds
+core,assert
+core,static_assert
+core,throw_exception
+


### PR DESCRIPTION
First proposal for CSV output. Since boostdep can mix different operations in the same command:

`boostdep --csv --primary assert --secondary container_hash --header boost/container/deque.hpp --reverse interprocess --subset assert`

...a table is created for each operation, prefixed by a table marker. The marker and the table header can be excluded using --csv-no-xxx options.