### PR TITLE
Improvements

### DIFF
--- a/src/boostdep.cpp
+++ b/src/boostdep.cpp
@@ -3361,7 +3361,8 @@ public:
 
 int main( int argc, char const* argv[] )
 {
-    if( argc < 2 )
+    const std::string first_option = argc < 2 ? "" : argv[1];
+    if( first_option.empty() || first_option == "-h" || first_option == "--help" )
     {
         std::cout <<
 


### PR DESCRIPTION
Add `--help` option and factor out a `boost_module` class

Introduces a class for handling e.g. the sub-paths for Boost modules.
This allows to keep the related logic more focused and consistent.

Also use that for validating the command line arguments expecting modules.


Motivation was that after passing e.g. `libs/locale` as an argument to `--cmake` which yielded a CML that was missing all files, dependencies and C++ standard setting instead of showing an error.