### PR TITLE
Fix Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,6 @@ jobs:
             os: ubuntu-latest
             install: clang-17
           - toolset: clang
-            cxxstd: "11,14,17,2a"
-            os: macos-11
-          - toolset: clang
             cxxstd: "11,14,17,20,2b"
             os: macos-12
           - toolset: clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:


### PR DESCRIPTION
Update for changes in runners

- Node 20 fails for older images
- MacOS 11 runner no longer exists