### PR TITLE
Remove testing of Boost.StaticAssert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,6 @@ jobs:
           - geometry
           - mp11
           - serialization
-          - static_assert
           - thread
           - throw_exception
           - uuid


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config and its submodule should be no longer used, so remove it from CI.